### PR TITLE
Add DownloadFile API

### DIFF
--- a/routes/download_file.go
+++ b/routes/download_file.go
@@ -1,0 +1,37 @@
+package routes
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/opacity/storage-node/utils"
+)
+
+type downloadFileReq struct {
+	AccountID string `json:"accountID" binding:"required,len=64"`
+	UploadID  string `json:"uploadID" binding:"required"`
+}
+
+type downloadFileRes struct {
+	// Url should point to S3, thus client does not need to download it from this node.
+	FileDownloadUrl string `json:"fileDownloadUrl"`
+	// Add other auth-token and expired within a certain period of time.
+}
+
+func DownloadFileHandler() gin.HandlerFunc {
+	return gin.HandlerFunc(uploadFile)
+}
+
+func downloadFile(c *gin.Context) {
+	request := downloadFileReq{}
+	if err := utils.ParseRequestBody(c.Request, &request); err != nil {
+		err = fmt.Errorf("bad request, unable to parse request body:  %v", err)
+		BadRequest(c, err)
+		return
+	}
+
+	OkResponse(c, downloadFileRes{
+		// Redirect to a different URL that client would have authorization to download it.
+		FileDownloadUrl: "http://barfoo.com",
+	})
+}

--- a/routes/router.go
+++ b/routes/router.go
@@ -72,10 +72,8 @@ func setupV1Paths(v1Router *gin.RouterGroup) {
 		c.JSON(http.StatusOK, "stub for doing a trial upload")
 	})
 
-	v1Router.POST("/uploads", UploadFileHandler())
-	v1Router.POST("/new-upload", func(c *gin.Context) {
-		c.JSON(http.StatusOK, "stub for uploading a file with an existing subscription")
-	})
+	v1Router.POST("/upload", UploadFileHandler())
+	v1Router.GET("/download", DownloadFileHandler())
 }
 
 func setupAdminPaths(router *gin.Engine) {


### PR DESCRIPTION
This allows client to send a request to server and get accessable downloadable URL for that particular file.
In this case, client does not need to know which backend it is stored in.