### PR TITLE
Change expected signature length, take public key instead of address, change accountID lengths

### DIFF
--- a/models/accounts.go
+++ b/models/accounts.go
@@ -16,7 +16,7 @@ import (
 
 /*Account defines a model for managing a user subscription for uploads*/
 type Account struct {
-	AccountID            string            `gorm:"primary_key" json:"accountID" binding:"required,len=40"` // some hash of the user's master handle
+	AccountID            string            `gorm:"primary_key" json:"accountID" binding:"required,len=64"` // some hash of the user's master handle
 	CreatedAt            time.Time         `json:"createdAt"`
 	UpdatedAt            time.Time         `json:"updatedAt"`
 	MonthsInSubscription int               `json:"monthsInSubscription" binding:"required,gte=1" example:"12"`                                                        // number of months in their subscription
@@ -80,6 +80,9 @@ const DefaultMonthsPerSubscription = 12
 
 /*BasicSubscriptionDefaultCost is the cost for a default-length term of the basic plan*/
 const BasicSubscriptionDefaultCost = 1.56
+
+/*AccountIDLength is the expected length of an accountID for an account*/
+const AccountIDLength = 64
 
 /*PaymentStatusMap is for pretty printing the PaymentStatus*/
 var PaymentStatusMap = make(map[PaymentStatusType]string)

--- a/models/accounts_test.go
+++ b/models/accounts_test.go
@@ -21,7 +21,7 @@ import (
 
 func returnValidAccount() Account {
 	ethAddress, privateKey, _ := services.EthWrapper.GenerateWallet()
-	accountID := utils.RandSeqFromRunes(40, []rune("abcdef01234567890"))
+	accountID := utils.RandSeqFromRunes(AccountIDLength, []rune("abcdef01234567890"))
 
 	return Account{
 		AccountID:            accountID,

--- a/performance_test.go
+++ b/performance_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"net/http"
-	"strings"
 
 	"os"
 
@@ -117,7 +116,9 @@ func performanceTest(numUploadsToDo int, t *testing.T) (numUploadsAttempted int,
 			fileHandle := uploadBody.FileHandle
 
 			// create a paid account
-			routes.CreatePaidAccountForTest(strings.TrimPrefix(request.Address, "0x"), t)
+			accountID, err := utils.HashString(request.PublicKey)
+			assert.Nil(t, err)
+			routes.CreatePaidAccountForTest(accountID, t)
 
 			// perform the first request and verify the expected status
 			w := routes.UploadFileHelperForTest(t, request)

--- a/routes/accounts_test.go
+++ b/routes/accounts_test.go
@@ -13,8 +13,6 @@ import (
 
 	"crypto/ecdsa"
 
-	"strings"
-
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -50,7 +48,7 @@ func returnValidCreateAccountReq(body accountCreateObj) accountCreateReq {
 func returnValidAccountAndPrivateKey() (models.Account, *ecdsa.PrivateKey) {
 	privateKeyToSignWith, _ := utils.GenerateKey()
 
-	accountID := strings.TrimPrefix(utils.PubkeyToAddress(privateKeyToSignWith.PublicKey).String(), "0x")
+	accountID, _ := utils.HashString(utils.PubkeyCompressedToHex(privateKeyToSignWith.PublicKey))
 
 	ethAddress, privateKey, _ := services.EthWrapper.GenerateWallet()
 

--- a/routes/accounts_test.go
+++ b/routes/accounts_test.go
@@ -82,7 +82,7 @@ func returnValidGetAccountReq(t *testing.T, body accountGetReqObj, privateKeyToS
 func returnValidAccount() models.Account {
 	ethAddress, privateKey, _ := services.EthWrapper.GenerateWallet()
 
-	accountID := utils.RandSeqFromRunes(40, []rune("abcdef01234567890"))
+	accountID := utils.RandSeqFromRunes(models.AccountIDLength, []rune("abcdef01234567890"))
 
 	return models.Account{
 		AccountID:            accountID,

--- a/routes/delete_file_test.go
+++ b/routes/delete_file_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/json"
 	"net/http"
-	"strings"
 	"testing"
 
 	"bytes"
@@ -92,7 +91,9 @@ func createAccountAndUploadFile(t *testing.T) (models.Account, string, *ecdsa.Pr
 	privateKey, err := utils.GenerateKey()
 	assert.Nil(t, err)
 	request := ReturnValidUploadFileReqForTest(t, uploadBody, privateKey)
-	account := CreatePaidAccountForTest(strings.TrimPrefix(request.Address, "0x"), t)
+	accountID, err := utils.HashString(request.PublicKey)
+	assert.Nil(t, err)
+	account := CreatePaidAccountForTest(accountID, t)
 
 	w := UploadFileHelperForTest(t, request)
 

--- a/routes/routes_test_utils.go
+++ b/routes/routes_test_utils.go
@@ -126,11 +126,12 @@ func setupVerificationWithPrivateKeyForTest(t *testing.T, reqBody string, privat
 	hash := utils.Hash([]byte(reqBody))
 
 	signature, err := utils.Sign(hash, privateKey)
+	signature = signature[:utils.SigLengthInBytes]
 	assert.Nil(t, err)
 
 	verification := verification{
 		Signature: hex.EncodeToString(signature),
-		PublicKey: utils.PubkeyToHex(privateKey.PublicKey),
+		PublicKey: utils.PubkeyCompressedToHex(privateKey.PublicKey),
 	}
 
 	return verification
@@ -146,11 +147,12 @@ func returnFailedVerificationForTest(t *testing.T, reqBody string) verification 
 	wrongPrivateKey, err := utils.GenerateKey()
 	assert.Nil(t, err)
 	signature, err := utils.Sign(hash, privateKeyToSignWith)
+	signature = signature[:utils.SigLengthInBytes]
 	assert.Nil(t, err)
 
 	verification := verification{
 		Signature: hex.EncodeToString(signature),
-		PublicKey: utils.PubkeyToHex(wrongPrivateKey.PublicKey),
+		PublicKey: utils.PubkeyCompressedToHex(wrongPrivateKey.PublicKey),
 	}
 
 	return verification

--- a/routes/routes_test_utils.go
+++ b/routes/routes_test_utils.go
@@ -130,7 +130,7 @@ func setupVerificationWithPrivateKeyForTest(t *testing.T, reqBody string, privat
 
 	verification := verification{
 		Signature: hex.EncodeToString(signature),
-		Address:   utils.PubkeyToAddress(privateKey.PublicKey).Hex(),
+		PublicKey: utils.PubkeyToHex(privateKey.PublicKey),
 	}
 
 	return verification
@@ -150,7 +150,7 @@ func returnFailedVerificationForTest(t *testing.T, reqBody string) verification 
 
 	verification := verification{
 		Signature: hex.EncodeToString(signature),
-		Address:   utils.PubkeyToAddress(wrongPrivateKey.PublicKey).Hex(),
+		PublicKey: utils.PubkeyToHex(wrongPrivateKey.PublicKey),
 	}
 
 	return verification

--- a/routes/upload_file_test.go
+++ b/routes/upload_file_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 
 	"math/big"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/ethereum/go-ethereum/common"
@@ -56,7 +55,9 @@ func Test_Upload_File_Account_Not_Paid(t *testing.T) {
 	privateKey, err := utils.GenerateKey()
 	assert.Nil(t, err)
 	request := ReturnValidUploadFileReqForTest(t, ReturnValidUploadFileBodyForTest(t), privateKey)
-	CreateUnpaidAccountForTest(strings.TrimPrefix(request.Address, "0x"), t)
+	accountID, err := utils.HashString(request.PublicKey)
+	assert.Nil(t, err)
+	CreateUnpaidAccountForTest(accountID, t)
 
 	models.BackendManager.CheckIfPaid = func(address common.Address, amount *big.Int) (bool, error) {
 		return false, nil
@@ -85,7 +86,9 @@ func Test_Upload_File_Account_Paid_Upload_Starts(t *testing.T) {
 	privateKey, err := utils.GenerateKey()
 	assert.Nil(t, err)
 	request := ReturnValidUploadFileReqForTest(t, uploadBody, privateKey)
-	CreatePaidAccountForTest(strings.TrimPrefix(request.Address, "0x"), t)
+	accountID, err := utils.HashString(request.PublicKey)
+	assert.Nil(t, err)
+	CreatePaidAccountForTest(accountID, t)
 
 	filesInDB := []models.File{}
 	models.DB.Where("file_id = ?", fileId).Find(&filesInDB)
@@ -118,7 +121,9 @@ func Test_Upload_File_Account_Paid_Upload_Continues(t *testing.T) {
 	privateKey, err := utils.GenerateKey()
 	assert.Nil(t, err)
 	request := ReturnValidUploadFileReqForTest(t, uploadBody, privateKey)
-	CreatePaidAccountForTest(strings.TrimPrefix(request.Address, "0x"), t)
+	accountID, err := utils.HashString(request.PublicKey)
+	assert.Nil(t, err)
+	CreatePaidAccountForTest(accountID, t)
 
 	w := UploadFileHelperForTest(t, request)
 
@@ -164,7 +169,9 @@ func Test_Upload_File_Completed_File_Is_Deleted(t *testing.T) {
 	privateKey, err := utils.GenerateKey()
 	assert.Nil(t, err)
 	request := ReturnValidUploadFileReqForTest(t, uploadBody, privateKey)
-	account := CreatePaidAccountForTest(strings.TrimPrefix(request.Address, "0x"), t)
+	accountID, err := utils.HashString(request.PublicKey)
+	assert.Nil(t, err)
+	account := CreatePaidAccountForTest(accountID, t)
 
 	w := UploadFileHelperForTest(t, request)
 

--- a/routes/user_stats_test.go
+++ b/routes/user_stats_test.go
@@ -70,7 +70,7 @@ func createCompletedFile(t *testing.T, fileSize int64) models.CompletedFile {
 }
 
 func createNewAccount(t *testing.T) models.Account {
-	accountID := utils.RandSeqFromRunes(40, []rune("abcdef01234567890"))
+	accountID := utils.RandSeqFromRunes(models.AccountIDLength, []rune("abcdef01234567890"))
 	ethAddress, privateKey, _ := services.EthWrapper.GenerateWallet()
 
 	account := models.Account{

--- a/routes/verification_utils.go
+++ b/routes/verification_utils.go
@@ -140,6 +140,8 @@ func returnAccountId(hash []byte, signature string, c *gin.Context) (string, err
 		return "", err
 	}
 
+	// TODO make sure this is the compressed public key and check with frontend that they'll be sending the compressed
+	// TODO version
 	accountID, err := utils.HashString(utils.PubkeyToHex(*publicKey))
 	if err != nil {
 		InternalErrorResponse(c, err)

--- a/utils/cryptography.go
+++ b/utils/cryptography.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-const sigLengthInBytes = 64
+const SigLengthInBytes = 64
 
 /*Encrypt encrypts a secret using a key and a nonce*/
 func Encrypt(key string, secret string, nonce string) []byte {
@@ -101,8 +101,8 @@ func Recover(hash []byte, sig []byte) (*ecdsa.PublicKey, error) {
 
 /*Verify verifies that a particular key was the signer of a message*/
 func Verify(pubKey []byte, hash []byte, sig []byte) (bool, error) {
-	if len(sig) > sigLengthInBytes {
-		sig = sig[:sigLengthInBytes]
+	if len(sig) > SigLengthInBytes {
+		sig = sig[:SigLengthInBytes]
 	}
 	return crypto.VerifySignature(pubKey, hash, sig), nil
 }
@@ -146,4 +146,10 @@ func PubkeyToAddress(p ecdsa.PublicKey) common.Address {
 /*PubkeyToHex takes a public key and converts it to a hex string*/
 func PubkeyToHex(p ecdsa.PublicKey) string {
 	return hex.EncodeToString(crypto.FromECDSAPub(&p))
+}
+
+/*PubkeyCompressedToHex takes a public key, compresses it and converts it to a hex string*/
+func PubkeyCompressedToHex(p ecdsa.PublicKey) string {
+	compressed := crypto.CompressPubkey(&p)
+	return hex.EncodeToString(compressed)
 }

--- a/utils/cryptography.go
+++ b/utils/cryptography.go
@@ -1,17 +1,16 @@
 package utils
 
 import (
-	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/ecdsa"
 	"encoding/hex"
 
-	"strings"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
+
+const sigLengthInBytes = 64
 
 /*Encrypt encrypts a secret using a key and a nonce*/
 func Encrypt(key string, secret string, nonce string) []byte {
@@ -81,6 +80,15 @@ func DecryptWithErrorReturn(key string, cipherText string, nonce string) ([]byte
 	})
 }
 
+/*HashString hashes input string arguments and outputs a hash encoded as a hex string*/
+func HashString(dataString string) (string, error) {
+	dataBytes, err := hex.DecodeString(dataString)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(crypto.Keccak256(dataBytes)), nil
+}
+
 /*Hash hashes input byte arguments*/
 func Hash(data ...[]byte) []byte {
 	return crypto.Keccak256(data...)
@@ -91,20 +99,18 @@ func Recover(hash []byte, sig []byte) (*ecdsa.PublicKey, error) {
 	return crypto.SigToPub(hash, sig)
 }
 
-/*Verify recovers a public key and checks it against an existing, known public key, and returns true if they match*/
-func Verify(address []byte, hash []byte, sig []byte) (bool, error) {
-	pubkey, err := Recover(hash, sig)
-	if err != nil {
-		return false, err
+/*Verify verifies that a particular key was the signer of a message*/
+func Verify(pubKey []byte, hash []byte, sig []byte) (bool, error) {
+	if len(sig) > sigLengthInBytes {
+		sig = sig[:sigLengthInBytes]
 	}
-	addr := PubkeyToAddress(*pubkey)
-
-	return bytes.Equal(address, addr[:]), err
+	return crypto.VerifySignature(pubKey, hash, sig), nil
 }
 
-/*VerifyFromStrings recovers a public key and checks it against an existing, known public key, and returns true if they match*/
-func VerifyFromStrings(address string, hash string, sig string) (bool, error) {
-	addressBytes, err := hex.DecodeString(strings.TrimPrefix(address, "0x"))
+/*VerifyFromStrings verifies that a particular key was the signer of a message, with hex strings
+as arguments*/
+func VerifyFromStrings(publicKey string, hash string, sig string) (bool, error) {
+	publicKeyBytes, err := hex.DecodeString(publicKey)
 	if err != nil {
 		return false, err
 	}
@@ -119,7 +125,7 @@ func VerifyFromStrings(address string, hash string, sig string) (bool, error) {
 		return false, err
 	}
 
-	return Verify(addressBytes, hashBytes, sigBytes)
+	return Verify(publicKeyBytes, hashBytes, sigBytes)
 }
 
 /*Sign signs a message with a private key*/
@@ -135,4 +141,9 @@ func GenerateKey() (*ecdsa.PrivateKey, error) {
 /*PubkeyToAddress takes a public key and converts it to an ethereum public address*/
 func PubkeyToAddress(p ecdsa.PublicKey) common.Address {
 	return crypto.PubkeyToAddress(p)
+}
+
+/*PubkeyToHex takes a public key and converts it to a hex string*/
+func PubkeyToHex(p ecdsa.PublicKey) string {
+	return hex.EncodeToString(crypto.FromECDSAPub(&p))
 }


### PR DESCRIPTION
-change endpoints to expect publicKey instead of address
-change cryptographic methods to expect a 64 byte signature instead of 65
-change accountID lengths from 40 to 64 and change how accountIDs are determined  

The first two changes are because of limitations in the libraries that the frontend devs have access, the last change was one I was going to handle in another PR but it made more sense to do it in this one.  