### PR TITLE
Remove file level lock

### DIFF
--- a/models/files.go
+++ b/models/files.go
@@ -15,8 +15,6 @@ import (
 	"github.com/opacity/storage-node/utils"
 )
 
-var getFileMutex = &sync.Mutex{}
-
 /*File defines a model for managing a user subscription for uploads*/
 type File struct {
 	/*FileID will either be the file handle, or a hash of the file handle.  We should add an appropriate length
@@ -107,8 +105,6 @@ func GetFileDataKey(fileID string) string {
 
 /*GetOrCreateFile - Get or create the file. */
 func GetOrCreateFile(file File) (*File, error) {
-	getFileMutex.Lock()
-	defer getFileMutex.Unlock()
 	var fileFromDB File
 	err := DB.Where(File{FileID: file.FileID}).Attrs(file).FirstOrCreate(&fileFromDB).Error
 

--- a/models/files.go
+++ b/models/files.go
@@ -1,13 +1,10 @@
 package models
 
 import (
-	"errors"
-	"time"
-
-	"fmt"
-
 	"encoding/json"
-	"sync"
+	"errors"
+	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -27,7 +24,6 @@ type File struct {
 	AwsObjectKey     *string   `json:"awsObjectKey"`
 	EndIndex         int       `json:"endIndex" binding:"required,gte=1"`
 	CompletedIndexes *string   `json:"completedIndexes" gorm:"type:mediumtext"`
-	sync.Mutex
 }
 
 type IndexMap map[int64]*s3.CompletedPart


### PR DESCRIPTION
Since we use init method, thus there is not need to use lock to lock the entire system.