### PR TITLE
updates

### DIFF
--- a/jobs/file_cleaner.go
+++ b/jobs/file_cleaner.go
@@ -10,7 +10,6 @@ import (
 type fileCleaner struct {
 }
 
-var newerThanOffset = -5 * time.Minute
 var olderThanOffset = -1 * 24 * time.Hour
 
 func (f fileCleaner) ScheduleInterval() string {

--- a/jobs/s3_deleter_test.go
+++ b/jobs/s3_deleter_test.go
@@ -19,11 +19,8 @@ func Test_DeleteAllExpiredCompletedFiles(t *testing.T) {
 	s2FileID := "test/foo2"
 	s3FileID := "test/foo3"
 
-	if utils.Env.DatabaseURL != utils.Env.TestDatabaseURL {
-		t.Fatalf("should only be calling deleteAccounts method on test database")
-	} else {
-		models.DB.Exec("DELETE from completed_files;")
-	}
+	models.DeleteCompletedFilesForTest(t)
+
 	s := models.CompletedFile{
 		FileID:    s1FileID,
 		ExpiredAt: time.Date(2009, 1, 1, 12, 0, 0, 0, time.UTC), // past

--- a/models/accounts_test.go
+++ b/models/accounts_test.go
@@ -424,6 +424,7 @@ func Test_PurgeOldUnpaidAccounts(t *testing.T) {
 	// before cutoff time, payment still in progress
 	// this one should get purged
 	accounts[3].CreatedAt = time.Now().Add(-1 * 8 * 24 * time.Hour)
+	accounts[3].StorageUsed = 0
 	accounts[3].PaymentStatus = InitialPaymentInProgress
 
 	accountToBeDeletedID := accounts[3].AccountID


### PR DESCRIPTION
Don't know why some people are having issues with accounts seemingly being deleted.  The only thing that deletes accounts in our code is the PurgeOldUnpaidAccounts method, and that should only work on an account that is past a certain age and still hasn't been paid for, but if the account has not been paid for, they shouldn't have been able to upload anything in the first place.  So this would only be happening if something was setting the accounts back to the original payment status, but I can't find anything that's doing that either.  So for now just to be safe I'm going to have PurgeOldUnpaidAccounts only delete accounts that have a StorageUsed of 0 in case somehow the accounts are getting set back to the initial payment status even after they've uploaded things already.  