### PR TITLE
Upgrade invoice

### DIFF
--- a/routes/router.go
+++ b/routes/router.go
@@ -46,6 +46,12 @@ const (
 	/*AccountDataPath is the path for retrieving data about an account*/
 	AccountDataPath = "/account-data"
 
+	/*AccountUpgradeInvoicePath is the path for getting an invoice to upgrade an account*/
+	AccountUpgradeInvoicePath = "/account/upgrade-status"
+
+	/*AccountUpgradePath is the path for upgrading an account*/
+	AccountUpgradePath = "/account/upgrade"
+
 	/*AdminPath is a router group for admin task. */
 	AdminPath = "/admin"
 
@@ -142,6 +148,7 @@ func returnV1Group(router *gin.Engine) *gin.RouterGroup {
 func setupV1Paths(v1Router *gin.RouterGroup) {
 	v1Router.POST(AccountsPath, CreateAccountHandler())
 	v1Router.POST(AccountDataPath, CheckAccountPaymentStatusHandler())
+	v1Router.POST(AccountUpgradeInvoicePath, GetAccountUpgradeInvoiceHandler())
 
 	v1Router.POST(MetadataSetPath, UpdateMetadataHandler())
 	v1Router.POST(MetadataGetPath, GetMetadataHandler())

--- a/routes/upgrade_account.go
+++ b/routes/upgrade_account.go
@@ -1,0 +1,63 @@
+package routes
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/opacity/storage-node/models"
+)
+
+type getUpgradeAccountInvoiceObject struct {
+	StorageLimit     int `json:"storageLimit" binding:"required,gte=100" minimum:"100" maximum:"100" example:"100"`
+	DurationInMonths int `json:"durationInMonths" binding:"required,gte=1" minimum:"1" example:"12"`
+}
+
+type upgradeAccountObject struct {
+	MetadataKeys     []string `json:"metadataKeys" binding:"required" example:"an array containing all your metadata keys"`
+	FileHandles      []string `json:"fileHandles" binding:"required" example:"an array containing all your file handles"`
+	StorageLimit     int      `json:"storageLimit" binding:"required,gte=100" minimum:"100" maximum:"100" example:"100"`
+	DurationInMonths int      `json:"durationInMonths" binding:"required,gte=1" minimum:"1" example:"12"`
+}
+
+type getUpgradeAccountInvoiceReq struct {
+	verification
+	requestBody
+	getUpgradeAccountInvoiceObject getUpgradeAccountInvoiceObject
+}
+
+type getUpgradeAccountInvoiceRes struct {
+	OpqInvoice models.Invoice `json:"opqInvoice"`
+	UsdInvoice float64        `json:"usdInvoice"`
+}
+
+func (v *getUpgradeAccountInvoiceReq) getObjectRef() interface{} {
+	return &v.getUpgradeAccountInvoiceObject
+}
+
+func GetAccountUpgradeInvoiceHandler() gin.HandlerFunc {
+	return ginHandlerFunc(getAccountUpgradeInvoice)
+}
+
+func getAccountUpgradeInvoice(c *gin.Context) error {
+	request := getUpgradeAccountInvoiceReq{}
+
+	if err := verifyAndParseBodyRequest(&request, c); err != nil {
+		return err
+	}
+
+	account, err := request.getAccount(c)
+	if err != nil {
+		return err
+	}
+
+	upgradeCostInOPQ, _ := account.UpgradeCostInOPQ(request.getUpgradeAccountInvoiceObject.StorageLimit,
+		request.getUpgradeAccountInvoiceObject.DurationInMonths)
+	upgradeCostInUSD, _ := account.UpgradeCostInUSD(request.getUpgradeAccountInvoiceObject.StorageLimit,
+		request.getUpgradeAccountInvoiceObject.DurationInMonths)
+
+	return OkResponse(c, getUpgradeAccountInvoiceRes{
+		OpqInvoice: models.Invoice{
+			Cost:       upgradeCostInOPQ,
+			EthAddress: account.EthAddress,
+		},
+		UsdInvoice: upgradeCostInUSD,
+	})
+}

--- a/routes/upgrade_account_test.go
+++ b/routes/upgrade_account_test.go
@@ -1,0 +1,41 @@
+package routes
+
+import (
+	"github.com/opacity/storage-node/models"
+	"github.com/opacity/storage-node/utils"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func Test_Init_Upgrade_Accounts(t *testing.T) {
+	setupTests(t)
+}
+
+func Test_GetAccountUpgradeInvoiceHandler_Returns_Invoice(t *testing.T) {
+	getInvoiceObj := getUpgradeAccountInvoiceObject{
+		StorageLimit:     2048,
+		DurationInMonths: 12,
+	}
+
+	v, b, _ := returnValidVerificationAndRequestBodyWithRandomPrivateKey(t, getInvoiceObj)
+
+	getInvoiceReq := getUpgradeAccountInvoiceReq{
+		verification: v,
+		requestBody:  b,
+	}
+
+	accountID, _ := utils.HashString(v.PublicKey)
+	account := CreatePaidAccountForTest(t, accountID)
+
+	account.StorageLimit = models.StorageLimitType(1024)
+	account.CreatedAt = time.Now().Add(time.Hour * 24 * (365 / 2) * -1)
+	models.DB.Save(&account)
+
+	w := httpPostRequestHelperForTest(t, AccountUpgradeInvoicePath, getInvoiceReq)
+	// Check to see if the response was what you expected
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"usdInvoice":100`)
+	assert.Contains(t, w.Body.String(), `"opqInvoice":{"cost":24,`)
+}


### PR DESCRIPTION
-adds an endpoint to return an upgrade invoice if they try to upgrade accounts
-adds methods to accounts model to pro-rate the cost of the upgrade
-tests  

More upgrade functionality will follow in future PRs.  